### PR TITLE
Fixes package entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "styled-components.macro",
   "version": "1.0.0",
-  "main": "index.js",
+  "main": "macro.js",
   "license": "MIT",
   "keywords": [
     "babel-plugin-macros"


### PR DESCRIPTION
The `main` entry points to `index.js` which doesn't exist caused the
package doesn't work with Jest.

Jest raise the following error when testing a module that depends on the
package.

```
Cannot find module 'styled-components.macro'
```